### PR TITLE
Fix usage of YschnorrProof.Verify and ShareschnorrProof.Verify in ccgmp

### DIFF
--- a/crypto/tss/ecdsa/cggmp/refresh/refresh_test.go
+++ b/crypto/tss/ecdsa/cggmp/refresh/refresh_test.go
@@ -35,7 +35,8 @@ func TestRefresh(t *testing.T) {
 
 var (
 	threshold = uint32(2)
-	publicKey = pt.ScalarBaseMult(elliptic.Secp256k1(), big1)
+	secret    = big.NewInt(2)
+	publicKey = pt.ScalarBaseMult(elliptic.Secp256k1(), secret)
 )
 
 var _ = Describe("Refresh", func() {
@@ -55,12 +56,12 @@ var _ = Describe("Refresh", func() {
 
 		r, err := refreshes[tss.GetTestID(0)].GetResult()
 		Expect(err).Should(BeNil())
-		shareA := big.NewInt(2)
+		shareA := big.NewInt(3)
 		afterShareA := new(big.Int).Add(r.refreshShare, shareA)
 
 		r, err = refreshes[tss.GetTestID(1)].GetResult()
 		Expect(err).Should(BeNil())
-		shareB := big.NewInt(3)
+		shareB := big.NewInt(4)
 		afterShareB := new(big.Int).Add(r.refreshShare, shareB)
 
 		allBks := birkhoffinterpolation.BkParameters{bks[tss.GetTestID(0)], bks[tss.GetTestID(1)]}
@@ -68,7 +69,6 @@ var _ = Describe("Refresh", func() {
 		Expect(err).Should(BeNil())
 		gotSecret := new(big.Int).Add(new(big.Int).Mul(afterShareA, bkcoefficient[0]), new(big.Int).Mul(afterShareB, bkcoefficient[1]))
 		gotSecret.Mod(gotSecret, publicKey.GetCurve().Params().N)
-		secret := big.NewInt(1)
 		Expect(gotSecret.Cmp(secret) == 0).Should(BeTrue())
 	})
 })

--- a/crypto/tss/ecdsa/cggmp/refresh/round_3.go
+++ b/crypto/tss/ecdsa/cggmp/refresh/round_3.go
@@ -163,12 +163,13 @@ func (p *round3Handler) HandleMessage(logger log.Logger, message types.Message) 
 	if !Ai.Equal(Aihat) {
 		return ErrDifferentPoint
 	}
-	// Because a2 = 0, so R can be arbitrary point.
-	err = round3Msg.YschnorrProof.Verify(p.pubKey, ssidSumRho)
+
+	G := pt.NewBase(curve)
+	err = round3Msg.YschnorrProof.Verify(G, ssidSumRho)
 	if err != nil {
 		return err
 	}
-	err = round3Msg.ShareschnorrProof.Verify(p.pubKey, ssidSumRho)
+	err = round3Msg.ShareschnorrProof.Verify(G, ssidSumRho)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I was playing around with this library and found the new `cggmp` module fails key refresh when `publicKey` is passed to `YschnorrProof.Verify` and `ShareschnorrProof.Verify` instead of the base point. I believe this is because the `R` value is part of the hashed inputs that make `c`. So even though `a2*R` will always be zero, a different `R` changes `c*V`.

The tests were passing because the `publicKey` used in the refresh test is defined as `publicKey = pt.ScalarBaseMult(elliptic.Secp256k1(), big1)`. I've updated the test to multiply the base point by `2`, which causes it to fail without my changes.

### Checklist

- [x] Fork [the repository](https://github.com/getamis/alice) and create your new branch from `master`.
- [ ] Please mention the name of community in Pull Request title.
- [x] Git Commit Messages
    - [x] Use the present tense (Also in Pull Request title): "Add feature" not "Added feature"
    - [x] Use the imperative mood (Also in Pull Request title): "Move cursor to..." not "Moves cursor to..."
    - [x] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.